### PR TITLE
fix: require minimum npm version for otp flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,13 @@ function run(argv) {
   }
 
   try {
+    var npmVersions = exec('npm --version').trim().split('.');
+    if (npmVersions[0] < 6 && argv.otp) {
+      // I'm not sure about npm v5, but I've verified the --otp switch is not
+      // documented for npm v4 and below.
+      throw new Error(
+          'The --otp switch only supports npm >= v6. Upgrade your node/nvm.');
+    }
     var publishCmd = 'npm publish';
     if (argv.otp) {
       publishCmd += ' --otp=' + argv.otp;
@@ -107,7 +114,7 @@ function run(argv) {
   } catch (e) {
     config.fatal = false;
     echo('');
-    echo(chalk.red.bold('Unable to publish, restoring previous repo state'));
+    echo(chalk.yellow.bold('Unable to publish, restoring previous repo state'));
 
     // Clean up
     var newVersion = require(path.resolve('.', 'package.json')).version;
@@ -145,7 +152,8 @@ function run(argv) {
       exit(1);
     }
 
-    echo(chalk.red.bold('Unknown error: ' + e));
+    var message = e.message || e;
+    echo(chalk.red.bold('Error: ' + message));
     exit(2);
   }
 


### PR DESCRIPTION
This adds an extra logic check to verify that we at least have the
minimum npm version which supports the --otp switch (as far as I can
tell, that's npm v6). Instead of attempting to `npm publish`, this
instead throws an error to tell the user to upgrade their npm
installation.

Note that this is not a new requirement; previously the `npm publish`
command would just fail and (confusingly) tell the user they need to use
the --otp switch. This change just makes the error output clearer.

Test: nvm use v7 (Node v7 comes with npm v4)
Test: npm run release:patch -- --otp=NO --release-branch=fix-require-min-npm-ver