### PR TITLE
refactor: switch to non-global shelljs import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-require('shelljs/global');
+var shell = require('shelljs');
 
 var path = require('path');
 
@@ -9,18 +9,13 @@ var minimist = require('minimist');
 var GIT_MAIN_BRANCHES = [ 'main', 'master' ];
 function findMainBranch() {
   for (branch of GIT_MAIN_BRANCHES) {
-    var branchExists = exec('git branch --list ' + branch, { silent: true }).trim() != '';
+    var branchExists = shell.exec('git branch --list ' + branch, { silent: true }).trim() != '';
     if (branchExists) {
       return branch;
     }
   }
   throw new Error('Cannot determine main branch of repo');
 }
-
-// npm version (bump version, commit, make tag)
-// echo npm publish
-//  - if successful, push commit & tag
-//  - if failed, undo commit & tag
 
 /**
  * Adds space characters to `str` until the return value is `length` characters
@@ -44,62 +39,62 @@ function usage() {
                                  '[' + GIT_MAIN_BRANCHES.join(', ') + '].',
   };
 
-  echo('');
-  echo('Usage: ' + process.argv[1] + ' [OPTION] <major|minor|patch>');
-  echo('');
-  echo('Available options:');
+  shell.echo('');
+  shell.echo('Usage: ' + process.argv[1] + ' [OPTION] <major|minor|patch>');
+  shell.echo('');
+  shell.echo('Available options:');
   var longestOption = Object.keys(options).reduce(function (accum, option) {
     return accum.length > option.length ? accum : option;
   }, '');
   var columnSize = longestOption.length + 2;
   Object.keys(options).forEach(function (option) {
     var description = options[option];
-    echo('  ' + rightPad(option, columnSize) + description);
+    shell.echo('  ' + rightPad(option, columnSize) + description);
   });
 }
 
 function gitBranch() {
-  var output = exec('git rev-parse --abbrev-ref HEAD', { silent: true });
+  var output = shell.exec('git rev-parse --abbrev-ref HEAD', { silent: true });
   if (output.code) {
     throw new Error('Unable to fetch git branch');
   }
   return output.stdout.trimRight();
 }
 
-config.silent = true;
+shell.config.silent = true;
 function run(argv) {
   if (argv.help) {
     usage();
-    exit(0);
+    shell.exit(0);
   }
   var version = argv._[0];
-  config.silent = false;
-  config.fatal = true;
+  shell.config.silent = false;
+  shell.config.fatal = true;
   var releaseBranch = argv['release-branch'] || findMainBranch();
   try {
     var currentBranch = gitBranch();
     if (currentBranch !== releaseBranch) {
-      echo('Please switch to the release branch: ' + releaseBranch);
-      echo('Currently on: ' + currentBranch);
-      exit(1);
+      shell.echo('Please switch to the release branch: ' + releaseBranch);
+      shell.echo('Currently on: ' + currentBranch);
+      shell.exit(1);
     }
   } catch (e) {
-    echo('Are you in a git repo?');
-    exit(1);
+    shell.echo('Are you in a git repo?');
+    shell.exit(1);
   }
 
   try {
-    echo('Publishing new ' + version + ' version');
-    echo('');
-    exec('npm version ' + version);
+    shell.echo('Publishing new ' + version + ' version');
+    shell.echo('');
+    shell.exec('npm version ' + version);
   } catch (e) {
-    echo('');
-    echo('Unable to bump version, is your repo clean?');
-    exit(1);
+    shell.echo('');
+    shell.echo('Unable to bump version, is your repo clean?');
+    shell.exit(1);
   }
 
   try {
-    var npmVersions = exec('npm --version').trim().split('.');
+    var npmVersions = shell.exec('npm --version').trim().split('.');
     if (npmVersions[0] < 6 && argv.otp) {
       // I'm not sure about npm v5, but I've verified the --otp switch is not
       // documented for npm v4 and below.
@@ -110,61 +105,61 @@ function run(argv) {
     if (argv.otp) {
       publishCmd += ' --otp=' + argv.otp;
     }
-    exec(publishCmd);
+    shell.exec(publishCmd);
   } catch (e) {
-    config.fatal = false;
-    echo('');
-    echo(chalk.yellow.bold('Unable to publish, restoring previous repo state'));
+    shell.config.fatal = false;
+    shell.echo('');
+    shell.echo(chalk.yellow.bold('Unable to publish, restoring previous repo state'));
 
     // Clean up
     var newVersion = require(path.resolve('.', 'package.json')).version;
     var tagName = 'v' + newVersion;
 
     // Delete the tag and undo the commit
-    echo('Removing git tag...');
-    var cleanTag = exec('git tag -d ' + tagName);
-    echo('Removing git commit...');
-    var cleanCommit = exec('git reset --hard HEAD~1');
+    shell.echo('Removing git tag...');
+    var cleanTag = shell.exec('git tag -d ' + tagName);
+    shell.echo('Removing git commit...');
+    var cleanCommit = shell.exec('git reset --hard HEAD~1');
     if (cleanTag.code === 0 && cleanCommit.code === 0) {
-      echo(chalk.white.bold('Successfully cleaned up commit and tag'));
+      shell.echo(chalk.white.bold('Successfully cleaned up commit and tag'));
     }
-    var npm_user = exec('npm whoami', { silent: true }).trimRight();
+    var npm_user = shell.exec('npm whoami', { silent: true }).trimRight();
     if (npm_user.toString() === '') {
-      config.silent = false;
-      echo('');
-      echo(chalk.yellow.bold(
+      shell.config.silent = false;
+      shell.echo('');
+      shell.echo(chalk.yellow.bold(
           'You must be logged in to NPM to publish, run "npm login" first.'));
-      exit(1);
+      shell.exit(1);
     }
-    config.silent = true;
-    var is_collaborator = exec('npm access ls-collaborators')
+    shell.config.silent = true;
+    var is_collaborator = shell.exec('npm access ls-collaborators')
                                .grep('.*' + npm_user + '.*:.*write.*')
                                .trimRight();
-    var is_owner = exec('npm owner ls').grep('.*' + npm_user + ' <.*')
+    var is_owner = shell.exec('npm owner ls').grep('.*' + npm_user + ' <.*')
                         .trimRight();
     if (is_collaborator + is_owner === '') {
       // Neither collaborator nor owner
-      config.silent = false;
-      echo(chalk.yellow.bold(
+      shell.config.silent = false;
+      shell.echo(chalk.yellow.bold(
           npm_user + ' does not have NPM write access. Request access from one of these fine folk:'));
-      echo('');
-      exec('npm owner ls');
-      exit(1);
+      shell.echo('');
+      shell.exec('npm owner ls');
+      shell.exit(1);
     }
 
     var message = e.message || e;
-    echo(chalk.red.bold('Error: ' + message));
-    exit(2);
+    shell.echo(chalk.red.bold('Error: ' + message));
+    shell.exit(2);
   }
 
-  config.silent = false;
+  shell.config.silent = false;
   try {
-    exec('git push origin ' + releaseBranch);
-    exec('git push --tags origin ' + releaseBranch);
+    shell.exec('git push origin ' + releaseBranch);
+    shell.exec('git push --tags origin ' + releaseBranch);
   } catch (e) {
-    echo('');
-    echo('Version has been released, but commit/tag could not be pushed.');
-    echo('Please push these manually.');
+    shell.echo('');
+    shell.echo('Version has been released, but commit/tag could not be pushed.');
+    shell.echo('Please push these manually.');
   }
 }
 
@@ -177,9 +172,9 @@ switch (argv._[0]) {
     break;
 
   default:
-    echo(chalk.yellow.bold(
+    shell.echo(chalk.yellow.bold(
         'Missing version bump argument (<major|minor|patch>)'));
     usage();
-    exit(1);
+    shell.exit(1);
     break;
 }


### PR DESCRIPTION
No change to logic. This switches from `require('shelljs/global')` to `require('shelljs')`. This is the recommended way of using ShellJS because it avoids polluting the global namespace.

Test: ./index.js --help
Test: npm run release:minor -- --release-branch=fake-release