### PR TITLE
fix: only push one git tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,6 +101,7 @@ function run(argv) {
       throw new Error(
           'The --otp switch only supports npm >= v6. Upgrade your node/nvm.');
     }
+    // 'npm publish' will internally call both 'git commit' and 'git tag'
     var publishCmd = 'npm publish';
     if (argv.otp) {
       publishCmd += ' --otp=' + argv.otp;
@@ -155,7 +156,9 @@ function run(argv) {
   shell.config.silent = false;
   try {
     shell.exec('git push origin ' + releaseBranch);
-    shell.exec('git push --tags origin ' + releaseBranch);
+    var newVersion = require(path.resolve('.', 'package.json')).version;
+    var tagName = 'v' + newVersion;
+    shell.exec('git push origin refs/tags/' + tagName);
   } catch (e) {
     shell.echo('');
     shell.echo('Version has been released, but commit/tag could not be pushed.');


### PR DESCRIPTION
This avoids an error when local git tags have a conflict with remote git tags. The easiest fix is to only push the one git tag associated with this release.

I noticed this when pushing shelljs v0.9.0 and I manually tested this by publishing shelljs-plugin-clear v0.3.0.